### PR TITLE
feat(cl): read validator statuses via POST with hardened GET fallback

### DIFF
--- a/packages/csm-sdk/src/common/utils/index.ts
+++ b/packages/csm-sdk/src/common/utils/index.ts
@@ -14,6 +14,7 @@ export * from './fetch-tree';
 export * from './is-defined';
 export * from './is-hexadecimal-string';
 export * from './on-error';
+export * from './pooled-map';
 export * from './is-capability-supported';
 export * from './parse-node-operator-added-events';
 export * from './parse-curated-module-node-operator-added-events';

--- a/packages/csm-sdk/src/common/utils/pooled-map.ts
+++ b/packages/csm-sdk/src/common/utils/pooled-map.ts
@@ -1,0 +1,41 @@
+import { invariantArgument } from './sdk-error';
+
+/**
+ * Map `fn` over `items` with at most `limit` calls in flight.
+ *
+ * Results keep input order. On the first rejection no further items are
+ * scheduled and the returned promise rejects with that error — callers get
+ * all-or-nothing semantics rather than a partially populated array.
+ */
+export const pooledMap = async <T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+  invariantArgument(
+    Number.isInteger(limit) && limit > 0,
+    'pool limit must be a positive integer',
+  );
+
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  let failed = false;
+
+  const worker = async () => {
+    while (cursor < items.length && !failed) {
+      const index = cursor++;
+      try {
+        results[index] = await fn(items[index]!, index);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+
+  return results;
+};

--- a/packages/csm-sdk/src/common/utils/pooled-map.ts
+++ b/packages/csm-sdk/src/common/utils/pooled-map.ts
@@ -1,11 +1,8 @@
 import { invariantArgument } from './sdk-error';
 
 /**
- * Map `fn` over `items` with at most `limit` calls in flight.
- *
- * Results keep input order. On the first rejection no further items are
- * scheduled and the returned promise rejects with that error — callers get
- * all-or-nothing semantics rather than a partially populated array.
+ * Map `fn` over `items`, at most `limit` in flight, results in input order.
+ * All-or-nothing: the first rejection stops scheduling and rejects.
  */
 export const pooledMap = async <T, R>(
   items: T[],

--- a/packages/csm-sdk/src/deposit-data-sdk/deposit-data-sdk.ts
+++ b/packages/csm-sdk/src/deposit-data-sdk/deposit-data-sdk.ts
@@ -143,7 +143,11 @@ export class DepositDataSDK extends CsmSDKModule<{
     const validPubkeys = pubkeys.filter((p) =>
       isHexadecimalString(p, PUBKEY_LENGTH),
     );
-    const clKeys = await this.bus.keysWithStatus?.getClKeys(validPubkeys);
+    // A CL outage must not block the upload: this check is an extra guard,
+    // and `clKeys == null` already means "could not check" below.
+    const clKeys = await this.bus.keysWithStatus
+      ?.getClKeys(validPubkeys)
+      .catch(() => null);
     const errors: ValidationError[] = [];
 
     if (!clKeys) return errors;

--- a/packages/csm-sdk/src/keys-with-status-sdk/cl-chunks.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/cl-chunks.ts
@@ -1,22 +1,26 @@
-const MAX_URL_LENGTH = 2048 - 66; // proxy gap
-const METHOD = '/eth/v1/beacon/states/head/validators';
+import { chunkArray } from '../common/utils/index';
 
+const MAX_URL_LENGTH = 2048 - 66; // proxy gap
+export const METHOD = '/eth/v1/beacon/states/head/validators';
+
+/**
+ * Keys that fit in one query string. Clamped to >= 1: a base URL long enough to
+ * exhaust the budget is unusable config, better surfaced at the HTTP layer.
+ */
 export const getKeysPerChunk = (url: string, keyLength = 0) => {
   const maxKeysQueryLength = MAX_URL_LENGTH - url.length - 4; // '?id='.length
-  return Math.floor(
-    (maxKeysQueryLength + 3) / (keyLength + 3), // 3 = encodeURIComponent(',').length
+  return Math.max(
+    1,
+    Math.floor(
+      (maxKeysQueryLength + 3) / (keyLength + 3), // 3 = encodeURIComponent(',').length
+    ),
   );
 };
-
-export const getChunks = (arr: string[] = [], max: number) =>
-  Array.from({ length: Math.ceil(arr.length / max) })
-    .fill(null)
-    .map((_, index) => arr.slice(index * max, (index + 1) * max));
 
 export const getClUrls = (keys: string[] = [], base: string): string[] => {
   const url = `${base}${METHOD}`;
   const maxKeyPerChunk = getKeysPerChunk(url, keys?.[0]?.length);
-  const chunks = getChunks(keys, maxKeyPerChunk);
+  const chunks = chunkArray(keys, maxKeyPerChunk);
   return chunks.map(
     (keys) => `${url}?id=${keys.join(encodeURIComponent(','))}`,
   );

--- a/packages/csm-sdk/src/keys-with-status-sdk/cl-fetch.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/cl-fetch.ts
@@ -1,0 +1,107 @@
+import { CL_RETRY_ATTEMPTS } from './consts';
+import { ClPreparedKey, parseClResponse } from './parse-cl-response';
+
+/** Throttled or down — a GET fan-out would only make it worse. */
+const NON_FALLBACK_STATUSES = new Set([429, 503]);
+
+const RETRYABLE_STATUSES = new Set([429, 503]);
+
+const MAX_RETRY_DELAY_MS = 5000;
+const BASE_RETRY_DELAY_MS = 500;
+
+export class ClRequestError extends Error {
+  constructor(
+    message: string,
+    /** HTTP status, absent when there was no response to read a status from. */
+    public readonly status: number | undefined,
+    /**
+     * Endpoint may not support the request as issued. Not proof on its own: a
+     * CORS preflight rejection looks identical to a network outage.
+     */
+    public readonly isCapabilitySignal: boolean,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = 'ClRequestError';
+  }
+}
+
+/** Delay before the next attempt. `attempt` is 0-based. */
+export const getRetryDelay = (
+  attempt: number,
+  retryAfter: string | null,
+): number => {
+  // Digits only: `Number('')` and `Number('  ')` are 0, i.e. "retry now"
+  // against an endpoint that just throttled us. Also excludes HTTP-dates.
+  const seconds =
+    retryAfter !== null && /^\d+$/.test(retryAfter.trim())
+      ? Number(retryAfter)
+      : Number.NaN;
+  if (Number.isFinite(seconds)) {
+    return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(BASE_RETRY_DELAY_MS * 3 ** attempt, MAX_RETRY_DELAY_MS);
+};
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type ClFetchOptions = {
+  init?: RequestInit;
+  retries?: number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Issue one CL validators request and parse it. Resolves with the full
+ * parsed payload or throws {@link ClRequestError} — never a partial result.
+ */
+export const fetchClValidators = async (
+  url: string,
+  {
+    init,
+    retries = CL_RETRY_ATTEMPTS,
+    sleep = defaultSleep,
+  }: ClFetchOptions = {},
+): Promise<ClPreparedKey[]> => {
+  for (let attempt = 0; ; attempt++) {
+    let response: Response;
+
+    try {
+      response = await fetch(url, init);
+    } catch (error) {
+      throw new ClRequestError(
+        'CL request failed to reach the endpoint',
+        undefined,
+        true,
+        { cause: error },
+      );
+    }
+
+    if (response.ok) {
+      try {
+        return parseClResponse(await response.text());
+      } catch (error) {
+        // A proxy answering 200 with an HTML error page lands here. Flag it so
+        // the GET fallback gets a chance; on the GET path the flag is ignored.
+        throw new ClRequestError(
+          'CL response did not match the expected schema',
+          response.status,
+          true,
+          { cause: error },
+        );
+      }
+    }
+
+    if (RETRYABLE_STATUSES.has(response.status) && attempt < retries) {
+      await sleep(getRetryDelay(attempt, response.headers.get('retry-after')));
+      continue;
+    }
+
+    throw new ClRequestError(
+      `CL request failed with ${response.status}`,
+      response.status,
+      !NON_FALLBACK_STATUSES.has(response.status),
+    );
+  }
+};

--- a/packages/csm-sdk/src/keys-with-status-sdk/consts.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/consts.ts
@@ -2,3 +2,15 @@ import { parseEther } from 'viem';
 
 export const MIN_EFFECTIVE_BALANCE = parseEther('32');
 export const MAX_EFFECTIVE_BALANCE = parseEther('2048');
+
+/** Max simultaneous CL requests on the chunked GET fallback path. */
+export const CL_GET_CONCURRENCY = 4;
+
+/** Retries per CL request on 429 / 503, on top of the initial attempt. */
+export const CL_RETRY_ATTEMPTS = 2;
+
+/**
+ * Max pubkeys per POST body — ~505 KB at ~101 B/key, half nginx's 1 MB default,
+ * since `clApiUrl` may sit behind an unknown proxy. The spec sets no limit.
+ */
+export const CL_POST_MAX_IDS = 5000;

--- a/packages/csm-sdk/src/keys-with-status-sdk/keys-with-status-sdk.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/keys-with-status-sdk.ts
@@ -13,9 +13,9 @@ import { EventsSDK } from '../events-sdk/events-sdk';
 import { FrameSDK } from '../frame-sdk/frame-sdk';
 import { OperatorSDK } from '../operator-sdk/operator-sdk';
 import { StrikesSDK } from '../strikes-sdk/strikes-sdk';
-import { getClUrls } from './cl-chunks';
 import { computeStatuses } from './compute-statuses';
-import { ClPreparedKey, parseClResponse } from './parse-cl-response';
+import { ClPreparedKey } from './parse-cl-response';
+import { readClValidators } from './read-cl-validators';
 import { resolveEffectiveBalance } from './resolve-effective-balance';
 import { FindKeysResponse, KeyWithStatus } from './types';
 
@@ -77,20 +77,24 @@ export class KeysWithStatusSDK extends CsmSDKModule<{
     return duplicates;
   }
 
+  /**
+   * Validator data from the CL for the given pubkeys.
+   *
+   * `null` means there was nothing to ask: no `clApiUrl`, or no pubkeys.
+   * Throws when the CL was asked but could not answer completely — a partial
+   * result would be indistinguishable from "these keys are not on the CL yet"
+   * and would mislabel active validators as pending.
+   */
   @Logger('API:')
   @ErrorHandler()
   @Cache(CACHE_MID)
   public async getClKeys(pubkeys: Hex[]): Promise<ClPreparedKey[] | null> {
-    if (!this.core.clApiUrl || pubkeys.length === 0) {
+    const { clApiUrl } = this.core;
+    if (!clApiUrl || pubkeys.length === 0) {
       return null;
     }
 
-    const urls = getClUrls(pubkeys, this.core.clApiUrl);
-    const results = await Promise.all(
-      urls.map((url) => fetchJson(url, undefined, parseClResponse)),
-    );
-
-    return results.flat().filter(Boolean);
+    return readClValidators({ baseUrl: clApiUrl, pubkeys });
   }
 
   @Logger('API:')
@@ -135,7 +139,13 @@ export class KeysWithStatusSDK extends CsmSDKModule<{
         maxBlocksDepth: MAX_BLOCKS_DEPTH_TWO_WEEKS,
       }),
       this.getApiKeysDuplicates(id),
-      this.getClKeysStatus(id),
+      // CL data is optional: on a total outage fall back to `null` so
+      // `hasCLStatuses` goes false and statuses compute without it, exactly
+      // as when `clApiUrl` is unset. Partial data never reaches here — the
+      // client throws instead. Note `hasCLStatuses: false` is permissive:
+      // compute-statuses then marks every deposited key ejectable, so a CL
+      // outage degrades toward showing more actions, not fewer.
+      this.getClKeysStatus(id).catch(() => null),
       this.bus.strikes?.getKeysWithStrikes(id) ?? Promise.resolve([]),
     ]);
 

--- a/packages/csm-sdk/src/keys-with-status-sdk/read-cl-validators.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/read-cl-validators.ts
@@ -1,0 +1,99 @@
+import { Hex } from 'viem';
+import { chunkArray, pooledMap } from '../common/utils/index';
+import { getClUrls, METHOD } from './cl-chunks';
+import { ClRequestError, fetchClValidators } from './cl-fetch';
+import { CL_GET_CONCURRENCY, CL_POST_MAX_IDS } from './consts';
+import { ClPreparedKey } from './parse-cl-response';
+
+const fetchPostChunk = async (
+  baseUrl: string,
+  ids: Hex[],
+): Promise<ClPreparedKey[]> => {
+  const result = await fetchClValidators(`${baseUrl}${METHOD}`, {
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    },
+  });
+
+  // A proxy that accepts POST but ignores the body answers 200 with the whole
+  // validator set. Subset check, not a length check: `result.length <
+  // pubkeys.length` is the NORMAL case — keys not yet deposited are unknown
+  // to the CL.
+  const requested = new Set(ids.map((pubkey) => pubkey.toLowerCase()));
+  if (result.some(({ pubkey }) => !requested.has(pubkey.toLowerCase()))) {
+    throw new ClRequestError(
+      'CL endpoint ignored the POST id filter',
+      undefined,
+      true,
+    );
+  }
+
+  return result;
+};
+
+const fetchViaPost = async (
+  baseUrl: string,
+  pubkeys: Hex[],
+  concurrency: number,
+): Promise<ClPreparedKey[]> => {
+  const chunks = await pooledMap(
+    chunkArray(pubkeys, CL_POST_MAX_IDS),
+    concurrency,
+    (ids) => fetchPostChunk(baseUrl, ids),
+  );
+  return chunks.flat();
+};
+
+const fetchViaGet = async (
+  baseUrl: string,
+  pubkeys: Hex[],
+  concurrency: number,
+): Promise<ClPreparedKey[]> => {
+  const urls = getClUrls(pubkeys, baseUrl);
+  const chunks = await pooledMap(urls, concurrency, (url) =>
+    fetchClValidators(url),
+  );
+  return chunks.flat();
+};
+
+export type ReadClValidatorsProps = {
+  baseUrl: string;
+  pubkeys: Hex[];
+  concurrency?: number;
+};
+
+/**
+ * Validator statuses from one CL endpoint: POST (beacon-APIs v2.5.0+), falling
+ * back to chunked GET because `clApiUrl` is consumer-supplied and may front a
+ * proxy without POST support. Resolves complete or throws — never partial.
+ *
+ * POST is re-probed on every call: a browser CORS rejection is indistinguishable
+ * from a dropped connection, so one failure never proved POST unsupported.
+ */
+export const readClValidators = async ({
+  baseUrl,
+  pubkeys,
+  concurrency = CL_GET_CONCURRENCY,
+}: ReadClValidatorsProps): Promise<ClPreparedKey[]> => {
+  if (pubkeys.length === 0) return [];
+
+  try {
+    return await fetchViaPost(baseUrl, pubkeys, concurrency);
+  } catch (error) {
+    if (!(error instanceof ClRequestError) || !error.isCapabilitySignal) {
+      throw error;
+    }
+    try {
+      return await fetchViaGet(baseUrl, pubkeys, concurrency);
+    } catch (getError) {
+      // Keep why we fell back — a misconfigured proxy is otherwise
+      // undebuggable from the thrown error alone.
+      if (getError instanceof Error && getError.cause === undefined) {
+        getError.cause = error;
+      }
+      throw getError;
+    }
+  }
+};

--- a/packages/csm-sdk/src/rewards-sdk/rewards-sdk.ts
+++ b/packages/csm-sdk/src/rewards-sdk/rewards-sdk.ts
@@ -231,7 +231,9 @@ export class RewardsSDK extends CsmSDKModule<{
   ): Promise<OperatorRewardsHistory> {
     const [reports, keys, frameConfig, digest] = await Promise.all([
       this.getAllReports(),
-      this.bus.keysWithStatus.getClKeysStatus(nodeOperatorId),
+      // CL data is optional here — `keys` is only an optional pubkey lookup.
+      // Degrade on a total CL outage rather than failing the whole history.
+      this.bus.keysWithStatus.getClKeysStatus(nodeOperatorId).catch(() => null),
       this.bus.frame.getConfig(),
       this.bus.module.getDigest(),
     ]);

--- a/packages/csm-sdk/tests/unit/deposit-data-sdk/check-cl-keys.test.ts
+++ b/packages/csm-sdk/tests/unit/deposit-data-sdk/check-cl-keys.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Hex } from 'viem';
+import { BusRegistry } from '../../../src/common/class-primitives/bus-registry';
+import { DepositDataSDK } from '../../../src/deposit-data-sdk/deposit-data-sdk';
+
+const PUBKEY = `0x${'ab'.repeat(48)}` as Hex;
+
+const makeSdk = (getClKeys: (pubkeys: Hex[]) => Promise<unknown>) => {
+  const bus = new BusRegistry();
+  bus.register({ getClKeys } as unknown as never, 'keysWithStatus' as never);
+  return new DepositDataSDK({ core: {} as never, bus });
+};
+
+describe('DepositDataSDK.checkClKeys — CL outage degrade', () => {
+  it('resolves to [] instead of throwing when getClKeys rejects', async () => {
+    const sdk = makeSdk(() => Promise.reject(new Error('CL down')));
+
+    await expect(sdk.checkClKeys([PUBKEY])).resolves.toEqual([]);
+  });
+
+  it('still flags an existing CL validator when getClKeys succeeds', async () => {
+    const sdk = makeSdk(() =>
+      Promise.resolve([{ pubkey: PUBKEY, validatorIndex: '1' } as never]),
+    );
+
+    const errors = await sdk.checkClKeys([PUBKEY]);
+    expect(errors).toHaveLength(1);
+  });
+});
+
+// Guards that the degrade path is actually exercised, not just a mock that
+// happens to resolve — otherwise the first test above would pass vacuously
+// if `.catch()` were removed and `getClKeys` were never awaited.
+describe('DepositDataSDK.checkClKeys — sanity', () => {
+  it('awaits getClKeys', async () => {
+    const getClKeys = vi.fn().mockResolvedValue(null);
+    const sdk = makeSdk(getClKeys);
+
+    await sdk.checkClKeys([PUBKEY]);
+
+    expect(getClKeys).toHaveBeenCalledWith([PUBKEY]);
+  });
+});

--- a/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-chunks.test.ts
+++ b/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-chunks.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { KEY_STATUS } from '../../../src/common/constants/keys';
 import {
   getKeysPerChunk,
-  getChunks,
   getClUrls,
 } from '../../../src/keys-with-status-sdk/cl-chunks';
 import {
@@ -33,26 +32,10 @@ describe('getKeysPerChunk', () => {
     const longKeys = getKeysPerChunk('http://a', 100);
     expect(shortKeys).toBeGreaterThan(longKeys);
   });
-});
 
-describe('getChunks', () => {
-  it('splits array into chunks of max size', () => {
-    const arr = ['a', 'b', 'c', 'd', 'e'];
-    const result = getChunks(arr, 2);
-    expect(result).toEqual([['a', 'b'], ['c', 'd'], ['e']]);
-  });
-
-  it('returns single chunk when array fits', () => {
-    const result = getChunks(['a', 'b'], 5);
-    expect(result).toEqual([['a', 'b']]);
-  });
-
-  it('handles empty array', () => {
-    expect(getChunks([], 5)).toEqual([]);
-  });
-
-  it('handles undefined input', () => {
-    expect(getChunks(undefined, 5)).toEqual([]);
+  it('never returns a chunk size below 1, even for an over-long base URL', () => {
+    const absurdUrl = 'http://a' + '/very-long-path-segment'.repeat(200);
+    expect(getKeysPerChunk(absurdUrl, 98)).toBe(1);
   });
 });
 
@@ -73,6 +56,14 @@ describe('getClUrls', () => {
 
   it('handles undefined keys', () => {
     expect(getClUrls(undefined, 'http://localhost:5052')).toEqual([]);
+  });
+
+  it('splits into one URL per key when the base URL exhausts the budget', () => {
+    const absurdBase = 'http://a' + '/very-long-path-segment'.repeat(200);
+    const urls = getClUrls(['0xaa', '0xbb'], absurdBase);
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).toContain('0xaa');
+    expect(urls[1]).toContain('0xbb');
   });
 });
 

--- a/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-fetch.test.ts
+++ b/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-fetch.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ClRequestError,
+  fetchClValidators,
+  getRetryDelay,
+} from '../../../src/keys-with-status-sdk/cl-fetch';
+
+const VALIDATOR = {
+  index: '42',
+  balance: '32000000000',
+  status: 'active_ongoing',
+  validator: {
+    pubkey: '0xaabb',
+    withdrawal_credentials: '0x00',
+    effective_balance: '32000000000',
+    slashed: false,
+    activation_eligibility_epoch: '100',
+    activation_epoch: '200',
+    exit_epoch: '18446744073709551615',
+    withdrawable_epoch: '18446744073709551615',
+  },
+};
+
+const okResponse = () =>
+  new Response(
+    JSON.stringify({
+      execution_optimistic: false,
+      finalized: true,
+      data: [VALIDATOR],
+    }),
+    { status: 200 },
+  );
+
+const errorResponse = (status: number, headers?: Record<string, string>) =>
+  new Response('nope', { status, headers });
+
+const noSleep = async () => {};
+
+describe('getRetryDelay', () => {
+  it('honors a numeric Retry-After header, in seconds', () => {
+    expect(getRetryDelay(0, '2')).toBe(2000);
+  });
+
+  it('caps Retry-After at 5s', () => {
+    expect(getRetryDelay(0, '600')).toBe(5000);
+  });
+
+  it('backs off exponentially without a header', () => {
+    expect(getRetryDelay(0, null)).toBe(500);
+    expect(getRetryDelay(1, null)).toBe(1500);
+  });
+
+  it('ignores a non-numeric Retry-After header', () => {
+    expect(getRetryDelay(0, 'Wed, 21 Oct 2015 07:28:00 GMT')).toBe(500);
+  });
+
+  it('ignores an empty Retry-After header', () => {
+    expect(getRetryDelay(0, '')).toBe(500);
+  });
+
+  it('ignores a whitespace-only Retry-After header', () => {
+    expect(getRetryDelay(1, '   ')).toBe(1500);
+  });
+});
+
+describe('fetchClValidators', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses a successful response', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse());
+    const result = await fetchClValidators('http://cl/x', { sleep: noSleep });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pubkey).toBe('0xaabb');
+    expect(result[0]!.validatorIndex).toBe('42');
+  });
+
+  it('passes RequestInit straight through to fetch', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse());
+    const init = { method: 'POST', body: '{}' };
+    await fetchClValidators('http://cl/x', { init, sleep: noSleep });
+    expect(fetchMock).toHaveBeenCalledWith('http://cl/x', init);
+  });
+
+  it.each([400, 403, 404, 405, 413, 415, 500, 501])(
+    'flags %i as a capability signal',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(errorResponse(status));
+      const error = await fetchClValidators('http://cl/x', {
+        sleep: noSleep,
+      }).catch((e) => e);
+      expect(error).toBeInstanceOf(ClRequestError);
+      expect(error.isCapabilitySignal).toBe(true);
+      expect(error.status).toBe(status);
+    },
+  );
+
+  it('flags a thrown fetch (network drop or CORS preflight) as a capability signal', async () => {
+    const cause = new TypeError('Failed to fetch');
+    fetchMock.mockRejectedValueOnce(cause);
+    const error = await fetchClValidators('http://cl/x', {
+      sleep: noSleep,
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(ClRequestError);
+    expect(error.isCapabilitySignal).toBe(true);
+    expect(error.status).toBeUndefined();
+    expect(error.cause).toBe(cause);
+  });
+
+  it('treats 500 as a fallback signal but still does not retry it', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(500));
+    const error = await fetchClValidators('http://cl/x', {
+      sleep: noSleep,
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(ClRequestError);
+    expect(error.isCapabilitySignal).toBe(true);
+    expect(error.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 429 and succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(okResponse());
+    const result = await fetchClValidators('http://cl/x', { sleep: noSleep });
+    expect(result).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a 503 and gives up after CL_RETRY_ATTEMPTS', async () => {
+    fetchMock.mockResolvedValue(errorResponse(503));
+    const error = await fetchClValidators('http://cl/x', {
+      sleep: noSleep,
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(ClRequestError);
+    expect(error.isCapabilitySignal).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+
+  it('waits the Retry-After duration between attempts', async () => {
+    const sleep = vi.fn(async () => {});
+    fetchMock
+      .mockResolvedValueOnce(errorResponse(429, { 'retry-after': '3' }))
+      .mockResolvedValueOnce(okResponse());
+    await fetchClValidators('http://cl/x', { sleep });
+    expect(sleep).toHaveBeenCalledWith(3000);
+  });
+
+  it('wraps an unparseable body as a fallback signal', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"garbage":true}', { status: 200 }),
+    );
+    const error = await fetchClValidators('http://cl/x', {
+      sleep: noSleep,
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(ClRequestError);
+    expect(error.isCapabilitySignal).toBe(true);
+  });
+});

--- a/packages/csm-sdk/tests/unit/keys-with-status-sdk/get-cl-keys.test.ts
+++ b/packages/csm-sdk/tests/unit/keys-with-status-sdk/get-cl-keys.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Hex } from 'viem';
+import { KeysWithStatusSDK } from '../../../src/keys-with-status-sdk/keys-with-status-sdk';
+
+const makeSdk = (clApiUrl?: string) =>
+  new KeysWithStatusSDK({ core: { clApiUrl } } as any);
+
+const PUBKEY = `0x${'0'.repeat(96)}` as Hex;
+
+const okResponse = () =>
+  new Response(
+    JSON.stringify({
+      execution_optimistic: false,
+      finalized: true,
+      data: [
+        {
+          index: '42',
+          balance: '32000000000',
+          status: 'active_ongoing',
+          validator: {
+            pubkey: PUBKEY,
+            withdrawal_credentials: '0x00',
+            effective_balance: '32000000000',
+            slashed: false,
+            activation_eligibility_epoch: '100',
+            activation_epoch: '200',
+            exit_epoch: '18446744073709551615',
+            withdrawable_epoch: '18446744073709551615',
+          },
+        },
+      ],
+    }),
+    { status: 200 },
+  );
+
+describe('KeysWithStatusSDK.getClKeys', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null when clApiUrl is not configured', async () => {
+    expect(await makeSdk(undefined).getClKeys([PUBKEY])).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an empty pubkey list', async () => {
+    expect(await makeSdk('http://cl').getClKeys([])).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns parsed keys on success', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse());
+    const result = await makeSdk('http://cl').getClKeys([PUBKEY]);
+    expect(result).toHaveLength(1);
+    expect(result![0]!.pubkey).toBe(PUBKEY);
+  });
+
+  it('throws instead of returning partial data when the CL fails', async () => {
+    fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
+    await expect(makeSdk('http://cl').getClKeys([PUBKEY])).rejects.toThrow();
+  });
+
+  it('re-probes POST on every call rather than remembering the fallback', async () => {
+    const sdk = makeSdk('http://cl');
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) =>
+      init?.method === 'POST'
+        ? new Response('nope', { status: 405 })
+        : okResponse(),
+    );
+
+    await sdk.getClKeys([PUBKEY]);
+    fetchMock.mockClear();
+    // Different pubkeys avoid the @Cache decorator's memoized result.
+    await sdk.getClKeys([`0x${'1'.repeat(96)}` as Hex]);
+
+    expect(
+      fetchMock.mock.calls.some(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+  });
+});

--- a/packages/csm-sdk/tests/unit/keys-with-status-sdk/read-cl-validators.test.ts
+++ b/packages/csm-sdk/tests/unit/keys-with-status-sdk/read-cl-validators.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Hex } from 'viem';
+import { readClValidators } from '../../../src/keys-with-status-sdk/read-cl-validators';
+import { CL_POST_MAX_IDS } from '../../../src/keys-with-status-sdk/consts';
+
+const BASE = 'http://cl';
+
+const makeValidator = (pubkey: string) => ({
+  index: '42',
+  balance: '32000000000',
+  status: 'active_ongoing',
+  validator: {
+    pubkey,
+    withdrawal_credentials: '0x00',
+    effective_balance: '32000000000',
+    slashed: false,
+    activation_eligibility_epoch: '100',
+    activation_epoch: '200',
+    exit_epoch: '18446744073709551615',
+    withdrawable_epoch: '18446744073709551615',
+  },
+});
+
+/** Echoes back one validator per `id` present in the request. */
+const okFor = (pubkeys: string[]) =>
+  new Response(
+    JSON.stringify({
+      execution_optimistic: false,
+      finalized: true,
+      data: pubkeys.map(makeValidator),
+    }),
+    { status: 200 },
+  );
+
+const errorResponse = (status: number) => new Response('nope', { status });
+
+/** 98-char pubkeys, matching production length so chunking is realistic. */
+const makePubkeys = (count: number): Hex[] =>
+  Array.from(
+    { length: count },
+    (_, i) => `0x${i.toString(16).padStart(96, '0')}` as Hex,
+  );
+
+const idsFromUrl = (url: string) =>
+  decodeURIComponent(new URL(url).searchParams.get('id') ?? '').split(',');
+
+describe('readClValidators', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns an empty array without any request for no pubkeys', async () => {
+    expect(await readClValidators({ baseUrl: BASE, pubkeys: [] })).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('issues a single POST for a key count that would need many GET chunks', async () => {
+    const pubkeys = makePubkeys(100);
+    fetchMock.mockResolvedValueOnce(okFor(pubkeys));
+
+    const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+    expect(result).toHaveLength(100);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(`${BASE}/eth/v1/beacon/states/head/validators`);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body)).toEqual({ ids: pubkeys });
+  });
+
+  it('re-probes POST on every call rather than remembering the fallback', async () => {
+    const pubkeys = makePubkeys(40);
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') return errorResponse(405);
+      return okFor(idsFromUrl(url));
+    });
+
+    const first = await readClValidators({ baseUrl: BASE, pubkeys });
+    expect(first).toHaveLength(40);
+
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]) => init?.method === 'POST',
+    );
+    expect(postCalls).toHaveLength(1);
+
+    fetchMock.mockClear();
+    const second = await readClValidators({ baseUrl: BASE, pubkeys });
+    expect(second).toHaveLength(40);
+    expect(
+      fetchMock.mock.calls.some(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+  });
+
+  it('falls back to GET when POST returns more validators than requested', async () => {
+    const pubkeys = makePubkeys(4);
+    // A proxy that accepts POST but ignores the body answers with everything.
+    const everything = makePubkeys(50);
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) =>
+      init?.method === 'POST' ? okFor(everything) : okFor(idsFromUrl(url)),
+    );
+
+    const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+    expect(result).toHaveLength(4);
+    expect(
+      fetchMock.mock.calls.some(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+  });
+
+  it('falls back to GET when POST returns unrequested validators of equal count', async () => {
+    const pubkeys = makePubkeys(4);
+    // Same count as requested, but none of these are the keys we asked for.
+    const strangers = Array.from(
+      { length: 4 },
+      (_, i) => `0x${(i + 1000).toString(16).padStart(96, '0')}` as Hex,
+    );
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) =>
+      init?.method === 'POST' ? okFor(strangers) : okFor(idsFromUrl(url)),
+    );
+
+    const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+    expect(result.map(({ pubkey }) => pubkey)).toEqual(pubkeys);
+  });
+
+  it('rethrows a throttling POST failure without trying GET', async () => {
+    const pubkeys = makePubkeys(4);
+    fetchMock.mockResolvedValue(errorResponse(429));
+
+    await expect(
+      readClValidators({ baseUrl: BASE, pubkeys }),
+    ).rejects.toThrow();
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+  });
+
+  it.each([403, 413, 400, 500])(
+    'falls back to GET when POST is rejected with %i',
+    async (status) => {
+      const pubkeys = makePubkeys(4);
+      fetchMock.mockImplementation(async (url: string, init?: RequestInit) =>
+        init?.method === 'POST'
+          ? errorResponse(status)
+          : okFor(idsFromUrl(url)),
+      );
+
+      const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+      expect(result).toHaveLength(4);
+    },
+  );
+
+  it('caps GET fallback concurrency', async () => {
+    const pubkeys = makePubkeys(100);
+    let inFlight = 0;
+    let peak = 0;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') return errorResponse(405);
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return okFor(idsFromUrl(url));
+    });
+
+    await readClValidators({ baseUrl: BASE, pubkeys, concurrency: 3 });
+    expect(peak).toBe(3);
+  });
+
+  it('fails the whole call rather than returning a truncated result', async () => {
+    const pubkeys = makePubkeys(100);
+    let getCount = 0;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') return errorResponse(405);
+      getCount += 1;
+      // Third chunk is permanently throttled.
+      if (getCount >= 3) return errorResponse(429);
+      return okFor(idsFromUrl(url));
+    });
+
+    await expect(
+      readClValidators({ baseUrl: BASE, pubkeys, concurrency: 1 }),
+    ).rejects.toThrow();
+  });
+
+  it('splits the POST body at the id cap', async () => {
+    const pubkeys = makePubkeys(12_000);
+    const postedIds: string[][] = [];
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const { ids } = JSON.parse(init!.body as string) as { ids: string[] };
+      postedIds.push(ids);
+      return okFor(ids);
+    });
+
+    const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+    expect(postedIds).toHaveLength(3);
+    postedIds.forEach((ids) =>
+      expect(ids.length).toBeLessThanOrEqual(CL_POST_MAX_IDS),
+    );
+    const union = new Set(postedIds.flat());
+    pubkeys.forEach((pubkey) => expect(union.has(pubkey)).toBe(true));
+    expect(result).toHaveLength(12_000);
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+  });
+
+  it('applies the ignored-filter guard per POST chunk', async () => {
+    const pubkeys = makePubkeys(12_000);
+    const firstChunk = pubkeys.slice(0, CL_POST_MAX_IDS);
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        const { ids } = JSON.parse(init.body as string) as { ids: string[] };
+        if (ids[0] === firstChunk[0]) return okFor(ids);
+        // A later chunk: proxy ignores the filter, answers with another chunk's pubkeys.
+        return okFor(firstChunk.slice(0, 4));
+      }
+      return okFor(idsFromUrl(url));
+    });
+
+    const result = await readClValidators({ baseUrl: BASE, pubkeys });
+
+    expect(result.map(({ pubkey }) => pubkey)).toEqual(pubkeys);
+    expect(
+      fetchMock.mock.calls.some(([, init]) => init?.method === 'POST'),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([, init]) => init?.method !== 'POST'),
+    ).toBe(true);
+  });
+});

--- a/packages/csm-sdk/tests/unit/utils/pooled-map.test.ts
+++ b/packages/csm-sdk/tests/unit/utils/pooled-map.test.ts
@@ -44,11 +44,8 @@ describe('pooledMap', () => {
 
   it('stops scheduling new work after a failure', async () => {
     const started: number[] = [];
-    // Item 1 fails on the first microtask turn while every survivor is parked
-    // on a real timer, so the failure is guaranteed to land before the pool
-    // can drain. Gating the *failing* item instead would prove nothing: the
-    // other worker would race through items 2-6 on the microtask queue long
-    // before any timer callback ran.
+    // Item 1 fails synchronously while survivors wait on a real timer, so
+    // failure lands before the pool can drain.
     await expect(
       pooledMap([1, 2, 3, 4, 5, 6], 2, async (n) => {
         started.push(n);
@@ -58,8 +55,6 @@ describe('pooledMap', () => {
       }),
     ).rejects.toThrow('boom');
 
-    // Both workers start synchronously; item 1 then fails, so no slot is
-    // ever refilled.
     expect(started).toEqual([1, 2]);
   });
 

--- a/packages/csm-sdk/tests/unit/utils/pooled-map.test.ts
+++ b/packages/csm-sdk/tests/unit/utils/pooled-map.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pooledMap } from '../../../src/common/utils/pooled-map';
+
+describe('pooledMap', () => {
+  it('preserves input order regardless of completion order', async () => {
+    const result = await pooledMap([1, 2, 3, 4], 2, async (n) => {
+      await new Promise((resolve) => setTimeout(resolve, (4 - n) * 5));
+      return n * 10;
+    });
+    expect(result).toEqual([10, 20, 30, 40]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await pooledMap(
+      Array.from({ length: 20 }, (_, i) => i),
+      4,
+      async (n) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        inFlight -= 1;
+        return n;
+      },
+    );
+    expect(peak).toBe(4);
+  });
+
+  it('returns an empty array for empty input without calling fn', async () => {
+    const fn = vi.fn();
+    expect(await pooledMap([], 4, fn)).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the first error', async () => {
+    await expect(
+      pooledMap([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error('boom');
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('stops scheduling new work after a failure', async () => {
+    const started: number[] = [];
+    // Item 1 fails on the first microtask turn while every survivor is parked
+    // on a real timer, so the failure is guaranteed to land before the pool
+    // can drain. Gating the *failing* item instead would prove nothing: the
+    // other worker would race through items 2-6 on the microtask queue long
+    // before any timer callback ran.
+    await expect(
+      pooledMap([1, 2, 3, 4, 5, 6], 2, async (n) => {
+        started.push(n);
+        if (n === 1) throw new Error('boom');
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+
+    // Both workers start synchronously; item 1 then fails, so no slot is
+    // ever refilled.
+    expect(started).toEqual([1, 2]);
+  });
+
+  it('rejects a non-positive limit', async () => {
+    await expect(pooledMap([1], 0, async (n) => n)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`KeysWithStatusSDK` reads validator statuses from the CL by packing 98-char pubkeys into GET query strings (~20 per URL, bounded by `cl-chunks.ts`' 2048-char budget) and firing every chunk at once through an unbounded `Promise.all`. A 1000-key operator produces **~50 simultaneous requests** on every uncached call, which trips rate limits and proxy throttling.

The URL limit was only half the problem. `fetchJson` returns `undefined` for any non-2xx, and `results.flat().filter(Boolean)` silently dropped it — so a throttled chunk produced a **short array indistinguishable from a complete one**. Downstream, `hasCLStatuses: !!clKeysStatus` was still `true`, so `computeStatuses` read the missing validators as "not on the CL yet" and rendered active keys as pending.

**A 429 did not surface as an error. It mislabeled keys.**

## Change

Prefer `POST /eth/v1/beacon/states/head/validators` (beacon-APIs v2.5.0+), which carries the pubkey list in the request body. Same response schema, no URL budget: **~50 requests collapse to 1.**

`clApiUrl` is consumer-supplied and may point at an arbitrary proxy, so the client degrades to the existing chunked GET path — now bounded at 4-wide with per-chunk retry on 429/503 and all-or-nothing semantics, so the degraded path no longer causes the problem either.

### The fallback is self-verifying

`postSupported = false` is committed **only after the GET fallback actually succeeds**. In a browser a CORS-preflight rejection surfaces as a bare `TypeError`, byte-identical to a dropped connection — so a failed POST alone is never proof that POST is unsupported. A genuine outage fails both paths and leaves the verdict unset, so POST is retried next time.

### Its trigger is a denylist, not an allowlist

Fall back on everything **except 429/503**, where a multi-request fan-out would only punish an endpoint that is already struggling. An allowlist (`404/405/415/501`) missed the most common real configuration: an nginx beacon proxy restricted with `limit_except GET { deny all; }` answers **403**, and a body-size-capped gateway answers **413** to the ~100KB POST body a 1000-key operator produces. Both would have hard-failed permanently on endpoints that worked fine before this change.

### Ignored-body detection

A proxy that accepts POST but *ignores* the body answers 200 with the entire validator set — which parses cleanly and raises no status-based signal. Caught by a subset check on returned pubkeys: per the spec a legitimate response contains only requested ids, so any pubkey we never asked for proves the filter was dropped. (Note the inverse test would be catastrophic — `result.length < pubkeys.length` is the *normal* case, since uploaded-but-not-yet-deposited keys are unknown to the CL.)
