### PR TITLE
fix(ipfs): harden gateway fallback with CIDv1, throttle retries and timeouts

### DIFF
--- a/packages/csm-sdk/src/common/constants/links.ts
+++ b/packages/csm-sdk/src/common/constants/links.ts
@@ -4,7 +4,8 @@ import { MODULE_NAME, PerModule } from './module-name';
 import { PerSupportedChain } from './supported-chains';
 
 export const DEFAULT_IPFS_GATEWAYS = [
-  'https://ipfs.io/ipfs/{cid}',
+  'https://{cid}.ipfs.dweb.link/',
+  'https://{cid}.ipfs.w3s.link/',
   'https://gateway.pinata.cloud/ipfs/{cid}',
 ];
 

--- a/packages/csm-sdk/src/common/utils/fetch-json.ts
+++ b/packages/csm-sdk/src/common/utils/fetch-json.ts
@@ -1,6 +1,22 @@
+import { defaultSleep, getRetryDelay } from './get-retry-delay';
+
 export type FetchFn<T> = (url: string) => Promise<T | null>;
 export type ParseFn<T> = (text: string) => T;
 export type ValidateFn<T> = (data: T) => boolean;
+
+const RETRYABLE_STATUSES = new Set([429, 503]);
+const FALLBACK_RETRY_ROUNDS = 2;
+const FALLBACK_REQUEST_TIMEOUT_MS = 10_000;
+
+export class HttpStatusError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly retryAfter: string | null,
+  ) {
+    super(`Request failed with ${status}`);
+    this.name = 'HttpStatusError';
+  }
+}
 
 type Fetcher = <T>(
   url: string,
@@ -15,8 +31,10 @@ export const fetchJson: Fetcher = async (url, params, parse) => {
   });
 
   if (!response.ok) {
-    // TODO: throw error ???
-    return undefined;
+    throw new HttpStatusError(
+      response.status,
+      response.headers.get('retry-after'),
+    );
   }
 
   if (parse) {
@@ -26,24 +44,64 @@ export const fetchJson: Fetcher = async (url, params, parse) => {
   return response.json();
 };
 
-export const fetchWithFallback = async <T>(
+type RoundOutcome<T> =
+  | { result: NonNullable<Awaited<T>> }
+  | { throttledUrls: string[]; minDelay: number };
+
+const runFallbackRound = async <T>(
   urls: Array<string | null>,
   fetch: FetchFn<T>,
-): Promise<NonNullable<Awaited<T>> | void> => {
+  round: number,
+): Promise<RoundOutcome<T>> => {
+  const throttledUrls: string[] = [];
+  let minDelay = Infinity;
+
   for (const url of urls) {
     if (!url) continue;
     try {
       const result = await fetch(url);
-      if (result) return result;
-    } catch {
-      /* noop */
+      if (result) return { result };
+    } catch (error) {
+      if (
+        error instanceof HttpStatusError &&
+        RETRYABLE_STATUSES.has(error.status)
+      ) {
+        throttledUrls.push(url);
+        minDelay = Math.min(minDelay, getRetryDelay(round, error.retryAfter));
+      }
     }
+  }
+
+  return { throttledUrls, minDelay };
+};
+
+export const fetchWithFallback = async <T>(
+  urls: Array<string | null>,
+  fetch: FetchFn<T>,
+  options?: { retries?: number; sleep?: (ms: number) => Promise<void> },
+): Promise<NonNullable<Awaited<T>> | void> => {
+  const { retries = FALLBACK_RETRY_ROUNDS, sleep = defaultSleep } =
+    options ?? {};
+
+  let pendingUrls = urls;
+  for (let round = 0; ; round++) {
+    const outcome = await runFallbackRound(pendingUrls, fetch, round);
+    if ('result' in outcome) return outcome.result;
+
+    const { throttledUrls, minDelay } = outcome;
+    if (throttledUrls.length === 0 || round >= retries) return;
+
+    await sleep(minDelay);
+    pendingUrls = throttledUrls;
   }
 };
 
 type FetchOneOfProps<T> = {
   urls: Array<string | null>;
   validate?: ValidateFn<T>;
+  retries?: number;
+  sleep?: (ms: number) => Promise<void>;
+  timeout?: number;
 } & (
   | {
       fetch?: FetchFn<T>;
@@ -62,14 +120,23 @@ export const fetchOneOf: FetchOneOf = async ({
   fetch,
   parse,
   validate,
+  retries,
+  sleep,
+  timeout = FALLBACK_REQUEST_TIMEOUT_MS,
 }) => {
-  return fetchWithFallback(urls, async (url) => {
-    const fetchFunction =
-      fetch ?? (async (url) => fetchJson(url, undefined, parse));
-    const data = await fetchFunction(url);
-    if (data && (!validate || validate(data))) {
-      return data;
-    }
-    return null;
-  });
+  return fetchWithFallback(
+    urls,
+    async (url) => {
+      const fetchFunction =
+        fetch ??
+        (async (url) =>
+          fetchJson(url, { signal: AbortSignal.timeout(timeout) }, parse));
+      const data = await fetchFunction(url);
+      if (data && (!validate || validate(data))) {
+        return data;
+      }
+      return null;
+    },
+    { retries, sleep },
+  );
 };

--- a/packages/csm-sdk/src/common/utils/get-retry-delay.ts
+++ b/packages/csm-sdk/src/common/utils/get-retry-delay.ts
@@ -1,0 +1,20 @@
+const MAX_RETRY_DELAY_MS = 5000;
+const BASE_RETRY_DELAY_MS = 500;
+
+/** Delay before the next attempt. `attempt` is 0-based. */
+export const getRetryDelay = (
+  attempt: number,
+  retryAfter: string | null,
+): number => {
+  const seconds =
+    retryAfter !== null && /^\d+$/.test(retryAfter.trim())
+      ? Number(retryAfter)
+      : Number.NaN;
+  if (Number.isFinite(seconds)) {
+    return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(BASE_RETRY_DELAY_MS * 3 ** attempt, MAX_RETRY_DELAY_MS);
+};
+
+export const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/packages/csm-sdk/src/common/utils/index.ts
+++ b/packages/csm-sdk/src/common/utils/index.ts
@@ -28,3 +28,5 @@ export * from './sdk-error';
 export * from './sdk-error-code';
 export * from './classify-error';
 export * from './decode-revert-data';
+export * from './to-cid-v1-base32';
+export * from './get-retry-delay';

--- a/packages/csm-sdk/src/common/utils/to-cid-v1-base32.ts
+++ b/packages/csm-sdk/src/common/utils/to-cid-v1-base32.ts
@@ -1,0 +1,65 @@
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+const decodeBase58 = (input: string): Uint8Array | null => {
+  const bytes = [0];
+
+  for (const char of input) {
+    const value = BASE58_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+
+    let carry = value;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i]! * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (let i = 0; input[i] === '1'; i++) {
+    bytes.push(0);
+  }
+
+  return new Uint8Array(bytes.reverse());
+};
+
+const encodeBase32 = (bytes: Uint8Array): string => {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 0x1f];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+
+  return output;
+};
+
+/** CIDv0 (base58btc `Qm…`) → CIDv1 base32. Anything else is returned unchanged. */
+export const toCidV1Base32 = (cid: string): string => {
+  if (!cid.startsWith('Qm')) return cid;
+
+  const decoded = decodeBase58(cid);
+  if (!decoded) return cid;
+
+  // A valid CIDv0 is a sha2-256 multihash: 0x12 (code) + 0x20 (32-byte digest length) + digest.
+  if (decoded.length !== 34 || decoded[0] !== 0x12 || decoded[1] !== 0x20) {
+    return cid;
+  }
+
+  const prefixed = new Uint8Array([0x01, 0x70, ...decoded]);
+  return `b${encodeBase32(prefixed)}`;
+};

--- a/packages/csm-sdk/src/core-sdk/core-sdk.ts
+++ b/packages/csm-sdk/src/core-sdk/core-sdk.ts
@@ -23,7 +23,7 @@ import {
   SUPPORTED_CHAINS,
   SUPPORTED_CONTRACT_VERSIONS,
 } from '../common/index';
-import { isValidIpfsCid } from '../common/utils/index';
+import { isValidIpfsCid, toCidV1Base32 } from '../common/utils/index';
 import { onVersionError } from '../common/utils/on-error';
 import {
   BindedContract,
@@ -193,12 +193,14 @@ export class CoreSDK extends CsmSDKCacheable {
   public getIpfsUrls(cid: string): string[] {
     if (!isValidIpfsCid(cid)) return [];
 
+    // subdomain gateways can't carry base58 CIDv0 — DNS labels are case-insensitive
+    const normalized = toCidV1Base32(cid);
     const gateways = [...this.ipfsGateways, ...DEFAULT_IPFS_GATEWAYS];
 
     return gateways.map((gateway) =>
       gateway.includes('{cid}')
-        ? gateway.replace('{cid}', cid)
-        : `${gateway}${cid}`,
+        ? gateway.replace('{cid}', normalized)
+        : `${gateway}${normalized}`,
     );
   }
 }

--- a/packages/csm-sdk/src/keys-with-status-sdk/cl-fetch.ts
+++ b/packages/csm-sdk/src/keys-with-status-sdk/cl-fetch.ts
@@ -1,3 +1,4 @@
+import { defaultSleep, getRetryDelay } from '../common/utils/index';
 import { CL_RETRY_ATTEMPTS } from './consts';
 import { ClPreparedKey, parseClResponse } from './parse-cl-response';
 
@@ -5,9 +6,6 @@ import { ClPreparedKey, parseClResponse } from './parse-cl-response';
 const NON_FALLBACK_STATUSES = new Set([429, 503]);
 
 const RETRYABLE_STATUSES = new Set([429, 503]);
-
-const MAX_RETRY_DELAY_MS = 5000;
-const BASE_RETRY_DELAY_MS = 500;
 
 export class ClRequestError extends Error {
   constructor(
@@ -25,26 +23,6 @@ export class ClRequestError extends Error {
     this.name = 'ClRequestError';
   }
 }
-
-/** Delay before the next attempt. `attempt` is 0-based. */
-export const getRetryDelay = (
-  attempt: number,
-  retryAfter: string | null,
-): number => {
-  // Digits only: `Number('')` and `Number('  ')` are 0, i.e. "retry now"
-  // against an endpoint that just throttled us. Also excludes HTTP-dates.
-  const seconds =
-    retryAfter !== null && /^\d+$/.test(retryAfter.trim())
-      ? Number(retryAfter)
-      : Number.NaN;
-  if (Number.isFinite(seconds)) {
-    return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
-  }
-  return Math.min(BASE_RETRY_DELAY_MS * 3 ** attempt, MAX_RETRY_DELAY_MS);
-};
-
-const defaultSleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export type ClFetchOptions = {
   init?: RequestInit;

--- a/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-fetch.test.ts
+++ b/packages/csm-sdk/tests/unit/keys-with-status-sdk/cl-fetch.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ClRequestError,
   fetchClValidators,
-  getRetryDelay,
 } from '../../../src/keys-with-status-sdk/cl-fetch';
 
 const VALIDATOR = {
@@ -35,33 +34,6 @@ const errorResponse = (status: number, headers?: Record<string, string>) =>
   new Response('nope', { status, headers });
 
 const noSleep = async () => {};
-
-describe('getRetryDelay', () => {
-  it('honors a numeric Retry-After header, in seconds', () => {
-    expect(getRetryDelay(0, '2')).toBe(2000);
-  });
-
-  it('caps Retry-After at 5s', () => {
-    expect(getRetryDelay(0, '600')).toBe(5000);
-  });
-
-  it('backs off exponentially without a header', () => {
-    expect(getRetryDelay(0, null)).toBe(500);
-    expect(getRetryDelay(1, null)).toBe(1500);
-  });
-
-  it('ignores a non-numeric Retry-After header', () => {
-    expect(getRetryDelay(0, 'Wed, 21 Oct 2015 07:28:00 GMT')).toBe(500);
-  });
-
-  it('ignores an empty Retry-After header', () => {
-    expect(getRetryDelay(0, '')).toBe(500);
-  });
-
-  it('ignores a whitespace-only Retry-After header', () => {
-    expect(getRetryDelay(1, '   ')).toBe(1500);
-  });
-});
 
 describe('fetchClValidators', () => {
   let fetchMock: ReturnType<typeof vi.fn>;

--- a/packages/csm-sdk/tests/unit/utils/fetch-json.test.ts
+++ b/packages/csm-sdk/tests/unit/utils/fetch-json.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   fetchWithFallback,
   fetchOneOf,
+  HttpStatusError,
 } from '../../../src/common/utils/fetch-json';
 
 describe('fetchWithFallback', () => {
@@ -60,6 +61,66 @@ describe('fetchWithFallback', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('retries only the throttled url in the next round', async () => {
+    const fetchFn = vi
+      .fn<(url: string) => Promise<string | null>>()
+      .mockRejectedValueOnce(new HttpStatusError(429, null))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('ok');
+
+    const result = await fetchWithFallback(['url1', 'url2'], fetchFn, {
+      sleep: async () => {},
+    });
+
+    expect(result).toBe('ok');
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(fetchFn).toHaveBeenNthCalledWith(1, 'url1');
+    expect(fetchFn).toHaveBeenNthCalledWith(2, 'url2');
+    expect(fetchFn).toHaveBeenNthCalledWith(3, 'url1');
+  });
+
+  it('sleeps with the Retry-After-derived delay before the next round', async () => {
+    const fetchFn = vi
+      .fn<(url: string) => Promise<string | null>>()
+      .mockRejectedValueOnce(new HttpStatusError(429, '3'))
+      .mockResolvedValueOnce('ok');
+    const sleep = vi.fn(async () => {});
+
+    await fetchWithFallback(['url1'], fetchFn, { sleep });
+
+    expect(sleep).toHaveBeenCalledWith(3000);
+  });
+
+  it('does not retry a non-retryable status', async () => {
+    const fetchFn = vi
+      .fn<(url: string) => Promise<string | null>>()
+      .mockRejectedValueOnce(new HttpStatusError(404, null))
+      .mockResolvedValueOnce('ok');
+    const sleep = vi.fn(async () => {});
+
+    const result = await fetchWithFallback(['url1'], fetchFn, { sleep });
+
+    expect(result).toBeUndefined();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the retry budget and returns undefined', async () => {
+    const fetchFn = vi
+      .fn<(url: string) => Promise<string | null>>()
+      .mockRejectedValue(new HttpStatusError(503, null));
+    const sleep = vi.fn(async () => {});
+
+    const result = await fetchWithFallback(['url1'], fetchFn, {
+      retries: 2,
+      sleep,
+    });
+
+    expect(result).toBeUndefined();
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('fetchOneOf', () => {
@@ -98,5 +159,51 @@ describe('fetchOneOf', () => {
     const result = await fetchOneOf({ urls: ['url1'], fetch: fetchFn });
 
     expect(result).toBeUndefined();
+  });
+
+  // real fetch rejects once its signal aborts; the stub must do the same to
+  // exercise the timeout path instead of hanging forever
+  const hangUntilAborted = (init?: RequestInit) =>
+    new Promise<Response>((_, reject) => {
+      init?.signal?.addEventListener('abort', () =>
+        reject(init.signal!.reason),
+      );
+    });
+
+  it('times out a hanging default fetch and falls back to the next url', async () => {
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'url1') return hangUntilAborted(init);
+      return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await fetchOneOf({
+      urls: ['url1', 'url2'],
+      parse: JSON.parse,
+      timeout: 20,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not retry a timed-out url in a later round', async () => {
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) =>
+      hangUntilAborted(init),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await fetchOneOf({
+      urls: ['url1'],
+      parse: JSON.parse,
+      timeout: 20,
+    });
+
+    expect(result).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
   });
 });

--- a/packages/csm-sdk/tests/unit/utils/get-retry-delay.test.ts
+++ b/packages/csm-sdk/tests/unit/utils/get-retry-delay.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { getRetryDelay } from '../../../src/common/utils/get-retry-delay';
+
+describe('getRetryDelay', () => {
+  it('honors a numeric Retry-After header, in seconds', () => {
+    expect(getRetryDelay(0, '2')).toBe(2000);
+  });
+
+  it('caps Retry-After at 5s', () => {
+    expect(getRetryDelay(0, '600')).toBe(5000);
+  });
+
+  it('backs off exponentially without a header', () => {
+    expect(getRetryDelay(0, null)).toBe(500);
+    expect(getRetryDelay(1, null)).toBe(1500);
+  });
+
+  it('ignores a non-numeric Retry-After header', () => {
+    expect(getRetryDelay(0, 'Wed, 21 Oct 2015 07:28:00 GMT')).toBe(500);
+  });
+
+  it('ignores an empty Retry-After header', () => {
+    expect(getRetryDelay(0, '')).toBe(500);
+  });
+
+  it('ignores a whitespace-only Retry-After header', () => {
+    expect(getRetryDelay(1, '   ')).toBe(1500);
+  });
+});

--- a/packages/csm-sdk/tests/unit/utils/to-cid-v1-base32.test.ts
+++ b/packages/csm-sdk/tests/unit/utils/to-cid-v1-base32.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { toCidV1Base32 } from '../../../src/common/utils/to-cid-v1-base32';
+
+describe('toCidV1Base32', () => {
+  it('converts the canonical multiformats CIDv0 to CIDv1 base32', () => {
+    expect(
+      toCidV1Base32('QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco'),
+    ).toBe('bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq');
+  });
+
+  it('returns a CIDv1 input unchanged', () => {
+    const cidV1 = 'bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq';
+    expect(toCidV1Base32(cidV1)).toBe(cidV1);
+  });
+
+  it('returns invalid base58 input unchanged', () => {
+    const invalid = 'Qm0abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP';
+    expect(toCidV1Base32(invalid)).toBe(invalid);
+  });
+
+  it('returns a wrong-length Qm string unchanged', () => {
+    const tooShort = 'QmShort';
+    expect(toCidV1Base32(tooShort)).toBe(tooShort);
+  });
+});


### PR DESCRIPTION
## Description

- Default pool swapped to `dweb.link` / `w3s.link` (subdomain) + `gateway.pinata.cloud`; 4everland dropped.
- `toCidV1Base32` normalizes CIDv0 → CIDv1 base32 in `getIpfsUrls`. Non-`Qm` input and anything that isn't a valid sha2-256 multihash passes through untouched.
- `fetchJson` throws a typed `HttpStatusError` (carrying `status` + `retry-after`) instead of swallowing `!response.ok`.
- `fetchWithFallback` gained throttle-aware retry rounds: it re-attempts **only** the URLs that returned 429/503, honoring `Retry-After`, and permanently drops hard failures and timeouts from later rounds. 2 rounds by default, `sleep` injectable for tests.
- 10s `AbortSignal.timeout` per request in `fetchOneOf` — a gateway missing a CID can hang, or only 504 after ~40s, which otherwise stalls the whole fallback chain.
- `getRetryDelay` / `defaultSleep` moved out of `keys-with-status-sdk/cl-fetch` into `common/utils` — now shared by both retry paths, no behavior change.

## Note

- **Subdomain gateways can't carry a base58 CIDv0.** DNS labels are case-insensitive, so `Qm…` in a subdomain position is invalid; only CIDv1 base32 works there.


## Test

`yarn test` — 593 unit tests pass (52 files). New coverage for `to-cid-v1-base32`, `get-retry-delay`, and the retry/timeout paths in `fetch-json`. Lint and `tsc --noEmit` clean.
